### PR TITLE
Emphasize indication of profiles

### DIFF
--- a/I-D-Profile-Negotiation.xml
+++ b/I-D-Profile-Negotiation.xml
@@ -45,14 +45,14 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="std" docName="draft-svensson-accept-profile-00" ipr="trust200902">
+<rfc category="std" docName="draft-svensson-content-profile-00" ipr="trust200902">
 	<!-- ***** FRONT MATTER ***** -->
 
 	<front>
 		<!-- The abbreviated title is used in the page header - it is only necessary if the 
 				full title is longer than 39 characters -->
 
-		<title>Negotiating Profiles in HTTP</title>
+		<title>Indicating and Negotiating Profiles in HTTP</title>
 
 		<author fullname="Lars G. Svensson" initials="L.G.S."
 				surname="Svensson">


### PR DESCRIPTION
I suggest to (at least equally) mention _indication_ as well. Conneg is a smaller use case (many APIs only have one content type) compared to indicating the profile (all APIs could use that).